### PR TITLE
International characters and stricter match detection

### DIFF
--- a/PapersCited.py
+++ b/PapersCited.py
@@ -24,7 +24,8 @@ class RegexPatterns:
     letter_character = "[a-zšđčćžäöüñáéíóúç'’\\-]"
     letter_uppercase = letter_character.upper()
     rest_of_word = letter_character[:-1] + letter_uppercase[1:] + "+"
-    years = "(?:\\(?\\d\\d\\d\\d[abcd]?,?\\s?;?)+"
+    # For years - must be exactly four digits, not followed by another digit.
+    years = "(?:\\(?\\d{4}(?!\\d)[abcd]?,?\\s?;?)+"
     phrase_and = " (?:and+|[i&]+) "
     phrase_et_al = "(?: et al[\\s,.(]+)"
     phrase_i_sur = "(?: i sur[\\s,.(]+)"

--- a/PapersCited.py
+++ b/PapersCited.py
@@ -26,7 +26,7 @@ class RegexPatterns:
     rest_of_word = letter_character[:-1] + letter_uppercase[1:] + "+"
     # For years - must be exactly four digits, not followed by another digit.
     years = "(?:\\(?\\d{4}(?!\\d)[abcd]?,?\\s?;?)+"
-    phrase_and = " (?:and+|[i&]+) "
+    phrase_and = " +(?:and+|[i&]+) +"
     phrase_et_al = "(?: et al[\\s,.(]+)"
     phrase_i_sur = "(?: i sur[\\s,.(]+)"
 

--- a/PapersCited.py
+++ b/PapersCited.py
@@ -21,7 +21,7 @@ from tkinter import filedialog
 
 class RegexPatterns:
     # Phrases that make up regex patterns for detecting citations
-    letter_character = "[a-zšđčćžäöüñáéíóú'’\\-]"
+    letter_character = "[a-zšđčćžäöüñáéíóúç'’\\-]"
     letter_uppercase = letter_character.upper()
     rest_of_word = letter_character[:-1] + letter_uppercase[1:] + "+"
     years = "(?:\\(?\\d\\d\\d\\d[abcd]?,?\\s?;?)+"

--- a/PapersCited.py
+++ b/PapersCited.py
@@ -49,10 +49,13 @@ class PhrasesToChange:
     croatian_excluded_phrases = [
       "^do[ ,]",
       "^i[ ,]",
+      "istraživanje",
       "^iz[ ,]",
       "^je[ ,]",
       "^još[ ,]",
       "^konačno[ ,]",
+      "metaanaliza",
+      "meta-analiza",
       "^nadalje[ ,]",
       "^nakon[ ,]",
       "^od[ ,]",

--- a/PapersCited.py
+++ b/PapersCited.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# V 1.2.0
+# V 1.2.1
 
 import locale
 locale.setlocale(locale.LC_ALL, "")

--- a/PapersCited.py
+++ b/PapersCited.py
@@ -180,7 +180,7 @@ class CitationType:
         for wider_citation in wide_citations:
             narrow_citation_no = 0
             found_match_for_wider_citation = False
-            while narrow_citation_no <= len(narrow_citations) and found_match_for_wider_citation == False:
+            while narrow_citation_no <= len(narrow_citations) - 1 and found_match_for_wider_citation == False:
                 if narrow_citations[narrow_citation_no] in wider_citation:
                     found_match_for_wider_citation = True
                     narrow_citations[narrow_citation_no] = "__DELETE__"
@@ -248,35 +248,30 @@ def read_document(filename):
     return(target_document)
 
 def get_matches_solo_author(text, drop_excluded_phrases = False):
-    # Regardless of case
     rx = RegexPatterns()
     matches = re.findall(
-        rx.letter_character + rx.rest_of_word + "[\\s,(]+" + rx.years,
-        text,
-        re.IGNORECASE)
+        rx.letter_uppercase + rx.rest_of_word + "[\\s,(]+" + rx.years,
+        text)
     matches = CitationType(matches)
     if drop_excluded_phrases: matches.drop_excluded_phrases()
     return(matches)
 
 def get_matches_two_authors(text, drop_excluded_phrases = False):
-    # Regardless of case
+    # The second word doesn't have to be uppercase, to catch "suradnici".
     rx = RegexPatterns()
     matches = re.findall(
-        rx.letter_character + rx.rest_of_word + rx.phrase_and +
-        rx.letter_character + rx.rest_of_word + "[\\s,(]+" + rx.years,
-        text,
-        re.IGNORECASE)
+        rx.letter_uppercase + rx.rest_of_word + rx.phrase_and +
+        rx.rest_of_word + "[\\s,(]+" + rx.years,
+        text)
     matches = CitationType(matches)
     if drop_excluded_phrases: matches.drop_excluded_phrases()
     return(matches)
 
 def get_matches_author_et_al(text, drop_excluded_phrases = False):
-    # Regardless of case
     rx = RegexPatterns()
     matches = re.findall(
-        rx.letter_character + rx.rest_of_word + "(?:" + rx.phrase_et_al + "|" + rx.phrase_i_sur + ")" + rx.years,
-        text,
-        re.IGNORECASE)
+        rx.letter_uppercase + rx.rest_of_word + "(?:" + rx.phrase_et_al + "|" + rx.phrase_i_sur + ")" + rx.years,
+        text)
     matches = CitationType(matches)
     if drop_excluded_phrases: matches.drop_excluded_phrases()
     return(matches)

--- a/tests/sample_text.txt
+++ b/tests/sample_text.txt
@@ -4,6 +4,6 @@ One can also list multiple works by certain authors (ProlificAuthor 2007, 2008a,
 When quoting exact pages, „the author should still be recognised“ (Writerly, 2001, p. 183).
 In 1989 is an example of a phrase that looks similar to a citation, but isn't, and shouldn't be detected as one. The 1999 study further exemplified the importance of such filtering.
 Tekst na hrvatskom
-Ovo je .docx proba (genius i Brainiac, 2008; Kolege i sur. 1999). Ako brainiac (2008, str. 92) više ne misli kao prije (Brainiac, 2007), tada ni mi (Darko i Bubamarko 2011) ni kolege (Manman i sur. 2022) nemamo što dodati. Èuturiæ i Èuèu (2009) ne bi trebali biti na kraju liste. Šverko i sur. (1989) takoðer. Tijekom 2019 utvrðeno je da se ovaj poèetak reèenice ne treba smatrati citatom.
+Ovo je .docx proba (Genius i Brainiac, 2008; Kolege i sur. 1999). Ako brainiac (2008, str. 92) više ne misli kao prije (Brainiac, 2007), tada ni mi (Darko i Bubamarko 2011) ni kolege (Manman i sur. 2022) nemamo što dodati. Èuturiæ i Èuèu (2009) ne bi trebali biti na kraju liste. Šverko i sur. (1989) takoðer. Tijekom 2019 utvrðeno je da se ovaj poèetak reèenice ne treba smatrati citatom.
 Sretno, Lucky i suradnici (2007) i Zanzibar (2011).
 

--- a/tests/sample_text_full_correct_list_citations.txt
+++ b/tests/sample_text_full_correct_list_citations.txt
@@ -4,10 +4,9 @@ AuthorOne 2022
 AuthorSecond & AuthorThird 1999
 AuthorThird 1999
 Brainiac 2007
-brainiac 2008
 Èuturiæ i Èuèu 2009
 Darko i Bubamarko 2011
-genius i Brainiac 2008
+Genius i Brainiac 2008
 Kolege i sur. 1999
 Lucky i sur. 2007
 Manman i sur. 2022

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -23,6 +23,11 @@ def test_dropping_citations_starting_with_excluded_phrases():
   croatian_uppercase = PapersCited.CitationType(["Dobar 2010", "Tijekom 2010", "Je 2010", "Tijekom, 2010"])
   croatian_uppercase.drop_excluded_phrases()
   assert croatian_uppercase.citations == ["Dobar 2010"]
+  croatian_research = PapersCited.CitationType(["Istraživanje Cooper i sur. 2019",
+                                                "Istraživanje Kleinlooga i sur. 2019",
+                                                "Meta-analiza Black i sur. 2015"])
+  croatian_research.drop_excluded_phrases()
+  assert croatian_research.citations == []
     
 def test_removing_extra_characters_from_citations():
   strings = ["(Swirly) 2000", ",Comma, 2000", "(Everything.); 2010"]

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -16,10 +16,13 @@ def test_dropping_citations_starting_with_excluded_phrases():
   citations.drop_excluded_phrases()
   assert citations.citations ==  ["b 2010"]
   
-  croatian_citations = PapersCited.CitationType(["dobar 2010", "tijekom 2010", "je 2010", "tijekom, 2010",])
+  croatian_citations = PapersCited.CitationType(["dobar 2010", "tijekom 2010", "je 2010", "tijekom, 2010"])
   croatian_citations.drop_excluded_phrases()
   assert croatian_citations.citations ==\
     ["dobar 2010"]
+  croatian_uppercase = PapersCited.CitationType(["Dobar 2010", "Tijekom 2010", "Je 2010", "Tijekom, 2010"])
+  croatian_uppercase.drop_excluded_phrases()
+  assert croatian_uppercase.citations == ["Dobar 2010"]
     
 def test_removing_extra_characters_from_citations():
   strings = ["(Swirly) 2000", ",Comma, 2000", "(Everything.); 2010"]

--- a/tests/test_detecting_authors.py
+++ b/tests/test_detecting_authors.py
@@ -129,3 +129,12 @@ def test_ignore_ISSN():
     text = "Online ISSN 2222-3333"
     citations = PapersCited.get_matches_two_surnames(text, drop_excluded_phrases= True)
     assert citations.citations == []
+    
+def test_ignore_serial_numbers():
+    text_with_long_serial = "Serial no 123456789"
+    assert PapersCited.get_matches_solo_author(text_with_long_serial).citations == []
+    # If a number is exactly four digits, it SHOULD get through the filter.
+    text_with_short_serial = "Serial no 1234"
+    assert PapersCited.get_matches_solo_author(text_with_short_serial).citations == ["no 1234"]
+    text_with_very_short_serial = "Serial no 12"
+    assert PapersCited.get_matches_solo_author(text_with_very_short_serial).citations == []

--- a/tests/test_detecting_authors.py
+++ b/tests/test_detecting_authors.py
@@ -33,6 +33,9 @@ def test_detecting_two_authors():
     test2 = "(Bennett i Maneval, 1998; "
     assert PapersCited.get_matches_two_authors(test2).citations ==\
         ["Bennett i Maneval, 1998;"]
+    foreign_characters_2 = "Mendonça i suradnici (2009) utvrdili su..."
+    assert PapersCited.get_matches_two_authors(foreign_characters_2).citations ==\
+        ["Mendonça i suradnici (2009"]
 
 def test_detecting_author_et_al():
     test_string_semicolon = "This is the facts (Truth et al., 1980). Also see Hard, 1980; Facts, 1989."

--- a/tests/test_detecting_authors.py
+++ b/tests/test_detecting_authors.py
@@ -9,9 +9,9 @@ def test_detecting_single_authors():
     # Best 2009 should not be detected as a citation.
     assert PapersCited.get_matches_solo_author(test_string).citations ==\
         ["Yado (2008", "Hailey (2010", "Worst (2000"]
-    test_string_lowercase = "Uppercase (1999) and lowercase (2000) both get detected."
+    test_string_lowercase = "Uppercase (1999) gets detected, while lowercase (2000) doesn't."
     assert PapersCited.get_matches_solo_author(test_string_lowercase).citations ==\
-        ["Uppercase (1999", "lowercase (2000"]
+        ["Uppercase (1999"]
     test_string_semicolon = "This is the facts (Truth, 1980). Also see Hard, 1980; Facts, 1989."
     assert PapersCited.get_matches_solo_author(test_string_semicolon).citations ==\
         ["Truth, 1980", "Hard, 1980;", "Facts, 1989"]
@@ -138,3 +138,10 @@ def test_ignore_serial_numbers():
     assert PapersCited.get_matches_solo_author(text_with_short_serial).citations == ["Number 1234"]
     text_with_very_short_serial = "Serial Number 12"
     assert PapersCited.get_matches_solo_author(text_with_very_short_serial).citations == []
+    
+def test_authors_should_be_capitalised_to_match():
+    single_author = "Stayed up all night running 1024 tests. If only I had listened to Testly (2000)."
+    assert PapersCited.get_matches_solo_author(single_author).citations == ["Testly (2000"]
+    two_authors = "Maybe writing and running 1024 tests a day takes too much time. Maybe yelling and Screaming 2000 times is better (Bogus and Dogus, 3000)."
+    assert PapersCited.get_matches_solo_author(two_authors).citations == ["Bogus and Dogues, 2000"]
+    # The second name can be lowercase to catch "suradnici".

--- a/tests/test_detecting_authors.py
+++ b/tests/test_detecting_authors.py
@@ -143,5 +143,5 @@ def test_authors_should_be_capitalised_to_match():
     single_author = "Stayed up all night running 1024 tests. If only I had listened to Testly (2000)."
     assert PapersCited.get_matches_solo_author(single_author).citations == ["Testly (2000"]
     two_authors = "Maybe writing and running 1024 tests a day takes too much time. Maybe yelling and Screaming 2000 times is better (Bogus and Dogus, 3000)."
-    assert PapersCited.get_matches_solo_author(two_authors).citations == ["Bogus and Dogues, 2000"]
+    assert PapersCited.get_matches_two_authors(two_authors).citations == ["Bogus and Dogus, 3000"]
     # The second name can be lowercase to catch "suradnici".

--- a/tests/test_detecting_authors.py
+++ b/tests/test_detecting_authors.py
@@ -131,10 +131,10 @@ def test_ignore_ISSN():
     assert citations.citations == []
     
 def test_ignore_serial_numbers():
-    text_with_long_serial = "Serial no 123456789"
+    text_with_long_serial = "Serial Number 123456789"
     assert PapersCited.get_matches_solo_author(text_with_long_serial).citations == []
     # If a number is exactly four digits, it SHOULD get through the filter.
-    text_with_short_serial = "Serial no 1234"
-    assert PapersCited.get_matches_solo_author(text_with_short_serial).citations == ["no 1234"]
-    text_with_very_short_serial = "Serial no 12"
+    text_with_short_serial = "Serial Number 1234"
+    assert PapersCited.get_matches_solo_author(text_with_short_serial).citations == ["Number 1234"]
+    text_with_very_short_serial = "Serial Number 12"
     assert PapersCited.get_matches_solo_author(text_with_very_short_serial).citations == []


### PR DESCRIPTION
Implemented fixes for the following issues:
#1 
#2 
#5 

Added new Croatian words to exclusion list:
*Istraživanje, metanaliza*

Improve multiple authors and duplicate detection:
"and" can now be preceded and followed by any number of spaces, not just one.