### PR TITLE
Separate lists of years into individual citations

### DIFF
--- a/PapersCited.py
+++ b/PapersCited.py
@@ -92,6 +92,7 @@ class CitationType:
         self.citations = self._remove_extra_characters(allow_commas)
         self.citations = self._separate_name_year()
         self.citations = self._adjust_common_phrases()
+        self.citations = self._separate_multiple_years()
         self.citations = self._remove_duplicates()
         self.citations = self._sort_citations()
     

--- a/PapersCited.py
+++ b/PapersCited.py
@@ -25,7 +25,7 @@ class RegexPatterns:
     letter_uppercase = letter_character.upper()
     rest_of_word = letter_character[:-1] + letter_uppercase[1:] + "+"
     # For years - must be exactly four digits, not followed by another digit.
-    years = "(?:\\(?\\d{4}(?!\\d)[abcd]?,?\\s?;?)+"
+    years = "(?:\\(?\\d{4}(?!\\d)[abcd]?,?\\s?;?\\s?)+"
     phrase_and = " +(?:and+|[i&]+) +"
     phrase_et_al = "(?: et al[\\s,.(]+)"
     phrase_i_sur = "(?: i sur[\\s,.(]+)"
@@ -151,6 +151,29 @@ class CitationType:
             for key in phrases_to_adjust:
                 clean_citations[index_no] = clean_citations[index_no].replace(key, phrases_to_adjust[key])
         return(clean_citations)
+    
+    def _separate_multiple_years(self):
+        rx = RegexPatterns()
+        all_citations = self.citations
+        # For each citation, find how many years it contains.
+        # If it contains more than one, get the years as a list.
+        # Flag the original citation for deletion
+        single_year_pattern = "\\d{4}[abcd]?"
+        all_years_pattern = rx.years
+        extracted_citations = []
+        
+        for index_no, citation in enumerate(all_citations):
+            years = re.findall(pattern = single_year_pattern, string = citation)
+            # findall always returns a list
+            if len(years) > 1:
+                citation_start = re.sub(all_years_pattern, "", citation)
+                all_citations[index_no] = "__DELETE__"
+                new_citations = [citation_start + year for year in years]
+                extracted_citations.extend(new_citations)
+        
+        expanded_citations = [citation for citation in all_citations if citation != "__DELETE__"]
+        expanded_citations.extend(extracted_citations)
+        return(expanded_citations)        
     
     def _remove_duplicates(self):
         citations = self.citations

--- a/PapersCited.py
+++ b/PapersCited.py
@@ -68,6 +68,7 @@ class PhrasesToChange:
       "^za[ ,]"
     ]
     english_excluded_phrases = [
+      "^-",
       "^a[ ,]",
       "^an[ ,]",
       "^at[ ,]",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PapersCited
-## v1.2.0
+## v1.2.1
 Write an Excel file containing all citations found in a document, so they can be used to check or build a reference list.
 
 ## Dependencies:
@@ -16,7 +16,7 @@ With that file, you can easily go through your reference list and note if you ci
 
 The first column is empty so you can easily mark certain citations as "OK" or "needs double-checking" when reviewing a reference list.
 
-Tested on Windows using .doc, .docx, .txt and .pdf files. 
+Tested on Windows 10 using .doc, .docx, .txt and .pdf files. 
 This program is appropriate for texts written in **English** and **Croatian**. Some sources may be detected incorrectly in other languages. The software is written with **APA style** citations in mind, but **Chicago style** and similar would work as well.
 
 ## Instructions:
@@ -43,7 +43,7 @@ With all that done, the script should run when double-clicked. If it asks you wh
 ## Known limitations:
 - Secondary citations ("*XX 2010, as cited in YY 2012*"). *YY 2012* is detected correctly. However, *XX 2010* also gets recorded as a primary source. *XX 2010* should not be included in the reference list.
 - In Croatian, different declinations of the author's surnames get detected as different authors.
-- Multiple surnames such as van der Flier will get recorded only as the last word - *Kappe and van der Flier (2010)* will be recorded as *Flier 2010*, **skipping the first author**! These require special attention when writing or reviewing a reference list. Multiple surnames with an "*-*", however, will be recorded correctly.
+- Surnames with three or more words, such as van der Flier, will get recorded only as the last word or last two words - *Kappe and van der Flier (2010)* will be recorded as *Flier 2010*, **skipping the first author**! These require special attention when writing or reviewing a reference list. Multiple surnames with an "*-*", however, will be recorded correctly.
 - Similarly, when citing organizations, laws and other documents, it possible that only the end of the full name gets recorded. *World Health Organization (2000)* will be recorded as *Organization 2000*, with *Health Organization 2000* as a separate suggestion. (*WHO 2000* would be fine, though.) So if you are working with these kinds of sources, extra attention is needed.
 
 ## Lastly...

--- a/tests/sample_text_full_correct_list_citations.txt
+++ b/tests/sample_text_full_correct_list_citations.txt
@@ -10,8 +10,10 @@ Genius i Brainiac 2008
 Kolege i sur. 1999
 Lucky i sur. 2007
 Manman i sur. 2022
-ProlificAuthor 2007 2008a 2010
+ProlificAuthor 2007
+ProlificAuthor 2008a
 ProlificAuthor 2008b
+ProlificAuthor 2010
 Spacey 1999
 Šverko i sur. 1989
 Writerly 2001

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -94,4 +94,5 @@ def test_no_newlines_in_citations():
 def test_separating_multiple_years():
   text = "AuthorA (2000; 2002; 2003) thoroughly explored..."
   matches = PapersCited.get_matches_solo_author(text)
-  assert matches._separate_multiple_years == ["AuthorA 2000", "AuthorA 2002", "AuthorA 2003"]
+  matches = PapersCited.CitationType(matches._remove_extra_characters())
+  assert matches._separate_multiple_years() == ["AuthorA 2000", "AuthorA 2002", "AuthorA 2003"]

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -96,3 +96,8 @@ def test_separating_multiple_years():
   matches = PapersCited.get_matches_solo_author(text)
   matches = PapersCited.CitationType(matches._remove_extra_characters())
   assert matches._separate_multiple_years() == ["AuthorA 2000", "AuthorA 2002", "AuthorA 2003"]
+  
+  text_abc = "AuthorA (2000a; 2000b; 2000c) thoroughly explored..."
+  matches = PapersCited.get_matches_solo_author(text_abc)
+  matches = PapersCited.CitationType(matches._remove_extra_characters())
+  assert matches._separate_multiple_years() == ["AuthorA 2000a", "AuthorA 2000b", "AuthorA 2000c"]

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -61,7 +61,14 @@ def test_cleanup():
   citations_many_spaces = PapersCited.CitationType(match_with_many_spaces)
   citations_many_spaces.cleanup()
   assert citations_many_spaces.citations == ["Manman 1999"]
-  
+
+def test_cleanup_multiple_years():
+  # All the helper methods need to be applied.
+  strings = ["survivor (2000a)", "(survivor, 2000b)", "survivor 2002", "Author et al 1000"]
+  citations = PapersCited.CitationType(strings)
+  citations.cleanup() # This doesn't return any values
+  assert citations.citations == ["Author et al. 1000", "survivor 2000a", "survivor 2000b", "survivor 2002"]
+
 def test_dropping_phrases_and_cleanup():
   strings = ["tijekom 1999", "survivor (2000)", "a 1999", "(survivor, 2000)", "survivor 2002", "Author et al 1000"]
   citations = PapersCited.CitationType(strings)

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -90,3 +90,8 @@ def test_no_newlines_in_citations():
   examples = PapersCited.CitationType([test1, test2])
   examples.cleanup()
   assert examples.citations == ["Aaa 2007", "Bbb 2010"]
+  
+def test_separating_multiple_years():
+  text = "AuthorA (2000; 2002; 2003) thoroughly explored..."
+  matches = PapersCited.get_matches_solo_author(text)
+  assert matches._separate_multiple_years == ["AuthorA 2000", "AuthorA 2002", "AuthorA 2003"]

--- a/tests/test_detecting_authors.py
+++ b/tests/test_detecting_authors.py
@@ -14,7 +14,7 @@ def test_detecting_single_authors():
         ["Uppercase (1999"]
     test_string_semicolon = "This is the facts (Truth, 1980). Also see Hard, 1980; Facts, 1989."
     assert PapersCited.get_matches_solo_author(test_string_semicolon).citations ==\
-        ["Truth, 1980", "Hard, 1980;", "Facts, 1989"]
+        ["Truth, 1980", "Hard, 1980; ", "Facts, 1989"]
     test_string_and = "Villa and Maria (1875) was the best show ever. Mirko i Birko (1999) napisali su cijelu knjigu o tome."
     # What this function detects WILL NOT be the whole citation. We still need it for controlling two-author matches.
     assert PapersCited.get_matches_solo_author(test_string_and).citations ==\
@@ -32,7 +32,7 @@ def test_detecting_two_authors():
         ["One and two (1212", "Aesop and Berry, 1999"]
     test2 = "(Bennett i Maneval, 1998; "
     assert PapersCited.get_matches_two_authors(test2).citations ==\
-        ["Bennett i Maneval, 1998;"]
+        ["Bennett i Maneval, 1998; "]
     foreign_characters_2 = "Mendonça i suradnici (2009) utvrdili su..."
     assert PapersCited.get_matches_two_authors(foreign_characters_2).citations ==\
         ["Mendonça i suradnici (2009"]


### PR DESCRIPTION
Add support for #3 Automatically separate citations from same authors in multiple years 

Additionaly,
* Citations cannot start with the "-" symbol, preventing incorrect matches.