### PR TITLE
Recognise all Unicode letter characters in author names

### DIFF
--- a/PapersCited.py
+++ b/PapersCited.py
@@ -68,7 +68,6 @@ class PhrasesToChange:
       "^za[ ,]"
     ]
     english_excluded_phrases = [
-      "^-",
       "^a[ ,]",
       "^an[ ,]",
       "^at[ ,]",

--- a/PapersCited.py
+++ b/PapersCited.py
@@ -21,7 +21,7 @@ from tkinter import filedialog
 
 class RegexPatterns:
     # Phrases that make up regex patterns for detecting citations
-    letter_character = "\\p{Ll}"
+    letter_lowercase = "\\p{Ll}"
     letter_uppercase = "\\p{Lu}"
     rest_of_word = "(?:\\p{L}|['’\\-])+"
     # For years - must be exactly four digits, not followed by another digit.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Write an Excel file containing all citations found in a document, so they can be
 
 ## Dependencies:
 This program was written using Python 3.9.12. It requires the following modules:
-textract, xlsxwriter
+textract, xlsxwriter, regex
 
-To install them in Powershell, type "*pip install textract*", followed by "*pip install xlsxwriter*".
+To install them in Powershell, type "*pip install textract*" and press Enter. After that, follow with "*pip install xlsxwriter*" and "*pip install regex*".
 
 # About:
 ***PapersCited*** is a small Python program designed to help you with **writing and reviewing reference lists** in your scientific articles. It reads through a document of your choice and takes a note every time something is cited. At the end, it writes all those citations in an Excel file in alphabetical order, omitting duplicate entries. 

--- a/tests/test_detecting_authors.py
+++ b/tests/test_detecting_authors.py
@@ -70,12 +70,12 @@ def test_detecting_two_surnames_i_suradnika():
         ["Anić Babić i suradnika (2000"]
 
 def test_detecting_two_surnames_et_al():
-        test_string_semicolon = "This is the facts (Naked Truth et al., 1980). Also see Hard, 1980; Facts, 1989."
-        assert PapersCited.get_matches_two_surnames_et_al(test_string_semicolon).citations ==\
-            ["Naked Truth et al., 1980"]
-        test_croatian_i_sur = "Branjek i suradnici (1999) spominju rad Cvanjek i suradnika (1990) više puta (Dvanjek Erin i sur., 2010)"
-        assert PapersCited.get_matches_two_surnames_et_al(test_croatian_i_sur).citations ==\
-            ["Dvanjek Erin i sur., 2010"]
+    test_string_semicolon = "This is the facts (Naked Truth et al., 1980). Also see Hard, 1980; Facts, 1989."
+    assert PapersCited.get_matches_two_surnames_et_al(test_string_semicolon).citations ==\
+        ["Naked Truth et al., 1980"]
+    test_croatian_i_sur = "Branjek i suradnici (1999) spominju rad Cvanjek i suradnika (1990) više puta (Dvanjek Erin i sur., 2010)"
+    assert PapersCited.get_matches_two_surnames_et_al(test_croatian_i_sur).citations ==\
+        ["Dvanjek Erin i sur., 2010"]
 
 def test_program_works_with_no_citations_found():
     document = ""
@@ -145,3 +145,8 @@ def test_authors_should_be_capitalised_to_match():
     two_authors = "Maybe writing and running 1024 tests a day takes too much time. Maybe yelling and Screaming 2000 times is better (Bogus and Dogus, 3000)."
     assert PapersCited.get_matches_two_authors(two_authors).citations == ["Bogus and Dogus, 3000"]
     # The second name can be lowercase to catch "suradnici".
+    
+def test_new_foreign_characters():
+    text = "Bø (1999) and Yø (2000) and Så (2001)"
+    assert PapersCited.get_matches_solo_author(text).citations ==\
+        ["Bø (1999", "Yø (2000", "Så (2001"]

--- a/tests/test_detecting_authors.py
+++ b/tests/test_detecting_authors.py
@@ -150,3 +150,6 @@ def test_new_foreign_characters():
     text = "Bø (1999) and Yø (2000) and Så (2001)"
     assert PapersCited.get_matches_solo_author(text).citations ==\
         ["Bø (1999", "Yø (2000", "Så (2001"]
+    text_non_alphanumeric = "Bø's (1999) research cited Yø-yoma (2000)"
+    assert PapersCited.get_matches_solo_author(text_non_alphanumeric).citations ==\
+        ["Bø's (1999", "Yø-yoma (2000"]


### PR DESCRIPTION
Implement #9 Support all Unicode characters.
Change the library used for regex from "re" to "regex", allowing use of the \p{L} special method for catching all Unicode letters, divided into uppercase, lowercase and both.