### PR TITLE
Adjust possesive form (Author's 1999) to proper (Author 1999)

### DIFF
--- a/PapersCited.py
+++ b/PapersCited.py
@@ -43,6 +43,8 @@ class PhrasesToChange:
       "suradnicima": "sur.",
       "suradnici": "sur.",
       "suradnika": "sur.",
+      # Change possesive form to a proper noun
+      "'s" : ""
     }
     # Before adding something to excluded phrases, Google [word] surname.
     # If anything shows up, don't include that word.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Write an Excel file containing all citations found in a document, so they can be
 
 ## Dependencies:
 This program was written using Python 3.9.12. It requires the following modules:
-textract, xlsxwriter
+textract, xlsxwriter, regex
 
-To install them in Powershell, type "*pip install textract*", followed by "*pip install xlsxwriter*".
+To install them in Powershell, type "*pip install textract*" and press Enter. Then follow it with "*pip install xlsxwriter*" and "*pip install regex*".
 
 # About:
 ***PapersCited*** is a small Python program designed to help you with **writing and reviewing reference lists** in your scientific articles. It reads through a document of your choice and takes a note every time something is cited. At the end, it writes all those citations in an Excel file in alphabetical order, omitting duplicate entries. 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Write an Excel file containing all citations found in a document, so they can be
 
 ## Dependencies:
 This program was written using Python 3.9.12. It requires the following modules:
-textract, xlsxwriter, regex
+textract, xlsxwriter
 
-To install them in Powershell, type "*pip install textract*" and press Enter. Then follow it with "*pip install xlsxwriter*" and "*pip install regex*".
+To install them in Powershell, type "*pip install textract*", followed by "*pip install xlsxwriter*".
 
 # About:
 ***PapersCited*** is a small Python program designed to help you with **writing and reviewing reference lists** in your scientific articles. It reads through a document of your choice and takes a note every time something is cited. At the end, it writes all those citations in an Excel file in alphabetical order, omitting duplicate entries. 

--- a/tests/test_detecting_authors.py
+++ b/tests/test_detecting_authors.py
@@ -151,3 +151,10 @@ def test_possesive_recognised_and_adjusted():
     matches = PapersCited.get_matches_solo_author(possesive_text)
     matches.cleanup()
     assert matches.citations == ["Cohen 1999"]
+    # When both possesive and regular form are cited, this should result in a single,
+    # proper form citation.
+    possesive_and_regular = "Listen to Cohen's (1999) talk. Or read Cohen (1999)"
+    matches = PapersCited.get_matches_solo_author(possesive_and_regular)
+    matches.cleanup()
+    assert matches.citations == ["Cohen 1999"]
+    

--- a/tests/test_detecting_authors.py
+++ b/tests/test_detecting_authors.py
@@ -158,3 +158,9 @@ def test_possesive_recognised_and_adjusted():
     matches.cleanup()
     assert matches.citations == ["Cohen 1999"]
     
+def test_surnames_apostrophe_s_recognised():
+    text = "O'Sullivan (2000) wrote a paper. Compare it to O'Samuel's (1999) work."
+    matches = PapersCited.get_matches_solo_author(text)
+    matches.cleanup()
+    assert matches.citations == ["O'Samuel 1999", "O'Sullivan 2000"]
+    

--- a/tests/test_detecting_authors.py
+++ b/tests/test_detecting_authors.py
@@ -145,3 +145,9 @@ def test_authors_should_be_capitalised_to_match():
     two_authors = "Maybe writing and running 1024 tests a day takes too much time. Maybe yelling and Screaming 2000 times is better (Bogus and Dogus, 3000)."
     assert PapersCited.get_matches_two_authors(two_authors).citations == ["Bogus and Dogus, 3000"]
     # The second name can be lowercase to catch "suradnici".
+    
+def test_possesive_recognised_and_adjusted():
+    possesive_text = "Listen to Cohen's (1999) talk."
+    matches = PapersCited.get_matches_solo_author(possesive_text)
+    matches.cleanup()
+    assert matches.citations == ["Cohen 1999"]


### PR DESCRIPTION
Resolve #10 Replace possesive form with proper noun in citation.

When both possesive and proper form are cited, the final list will include only a single, proper form citation.