### PR TITLE
Rename citations file

### DIFF
--- a/PapersCited.py
+++ b/PapersCited.py
@@ -344,8 +344,8 @@ def get_matches_two_surnames_et_al(text, drop_excluded_phrases = False):
 def write_excel(filename, citations, wider_citations):
     # Retrieve the directory in which the analysed document is located,
     # The output file will be created in the same directory.
-    output_folder = os.path.dirname(filename)
-    output_filename = output_folder + "/citations.xlsx"
+    output_file_prefix = os.path.splitext(filename)
+    output_filename = output_file_prefix[0] + "_citations.xlsx"
 
     # Create a file
     try:

--- a/PapersCited.py
+++ b/PapersCited.py
@@ -342,8 +342,9 @@ def get_matches_two_surnames_et_al(text, drop_excluded_phrases = False):
     return(matches)
             
 def write_excel(filename, citations, wider_citations):
-    # Retrieve the directory in which the analysed document is located,
-    # The output file will be created in the same directory.
+    # Retrieve the filepath (and extension) of the analysed document,
+    # The output file will have a similar name and be created 
+    # in the same directory.
     output_file_prefix = os.path.splitext(filename)
     output_filename = output_file_prefix[0] + "_citations.xlsx"
 

--- a/PapersCited.py
+++ b/PapersCited.py
@@ -386,7 +386,7 @@ def write_excel(filename, citations, wider_citations):
     except:
         total_citations = n_narrower_citations
     
-    print(f"Success! A file has been created at {output_filename}.")
+    print(f"Success! A file with found citations has been created: {output_filename}.")
     
     if n_wider_citations:
         print(f"{n_narrower_citations} citations have been found, along with" +


### PR DESCRIPTION
Instead of creating a file called "citations.xlsx", the created file will now be called the same as the original file, with "_citations.xlsx" appended.
This will make it easier to create citations for multiple files in the same directory.