### PR TITLE
Preview found citations when finished

### DIFF
--- a/PapersCited.py
+++ b/PapersCited.py
@@ -394,6 +394,14 @@ def write_excel(filename, citations, wider_citations):
     print(f"A total of {total_citations} different citations have been recorded.")
     input("\nPress Enter to exit the program.")
 
+def preview_citations(citations, wider_citations):
+    print("Citations found:")
+    [print(citation) for citation in citations.citations]
+    print("\n")
+    if wider_citations:
+        print("Wider citations found:")
+        [print(citation) for citation in wider_citations.citations]
+
 # MAIN ----
 
 def main():

--- a/PapersCited.py
+++ b/PapersCited.py
@@ -392,7 +392,7 @@ def write_excel(filename, citations, wider_citations):
               f" {n_wider_citations} wider citations, displayed to the right.")
     
     print(f"A total of {total_citations} different citations have been recorded.")
-    input("\nPress Enter to exit the program.")
+
 
 def preview_citations(citations, wider_citations):
     print("Citations found:")
@@ -433,3 +433,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+    input("\nPress Enter to exit the program.")

--- a/PapersCited.py
+++ b/PapersCited.py
@@ -395,6 +395,7 @@ def write_excel(filename, citations, wider_citations):
 
 
 def preview_citations(citations, wider_citations):
+    print("\n")
     print("Citations found:")
     [print(citation) for citation in citations.citations]
     print("\n")

--- a/PapersCited.py
+++ b/PapersCited.py
@@ -430,6 +430,7 @@ def main():
     narrower_citations.cleanup()
     wider_citations.cleanup(allow_commas = False) # False prevents lots of duplication
     write_excel(filename, narrower_citations, wider_citations)
+    preview_citations(narrower_citations, wider_citations)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
After processing a file, list all found citations in the console as preview, so you don't have to open the Excel file.
Narrower citations are displayed first, then wider ones.