### PR TITLE
Preview wider citations only if any found

### DIFF
--- a/PapersCited.py
+++ b/PapersCited.py
@@ -404,8 +404,8 @@ def preview_citations(citations, wider_citations):
     print("\n")
     print("Citations found:")
     [print(citation) for citation in citations.citations]
-    print("\n")
-    if wider_citations:
+    if len(wider_citations.citations) > 0:
+        print("\n")
         print("Wider citations found:")
         [print(citation) for citation in wider_citations.citations]
 


### PR DESCRIPTION
# Description
Small fix after #17 Preview found citations when finished.

The text "Wider citations found:" was displayed after every successful processing.
Now it only appears if there were any wider citations found.  
*(Wider citations are those that include authors with several surnames. These have a slightly higher chance of being incorrect, so they are logged and displayed separately.)*