### PR TITLE
Cancel saving if user cancel the dialog

### DIFF
--- a/PapersCited/UI/appData.py
+++ b/PapersCited/UI/appData.py
@@ -114,6 +114,10 @@ class AppData:
             filetypes= (filetype, ) # Tuple of tuples required, single item requires comma
             )
         
+        # Check if user cancelled the action:
+        if user_filename == "":
+            raise(Exception("Saving cancelled."))
+        
         return(user_filename)
     
     def get_citations(self):

--- a/PapersCited/UI/messages.py
+++ b/PapersCited/UI/messages.py
@@ -56,3 +56,6 @@ def cant_write_file(filename):
 reading_txt_warning = "Warning! " + \
     "If you encounter problems reading this .txt file, backup the original file, then try saving it in UTF-8 or ANSI encoding.\
     \n(\"Save as...\" dialog, \"Encoding:\" at the bottom.)\n"
+    
+saving_cancelled = "\n" + break_with_lines + \
+    "\nSaving cancelled."

--- a/PapersCited/UI/windowUI.py
+++ b/PapersCited/UI/windowUI.py
@@ -136,7 +136,13 @@ def fn_btn_save_excel(event):
     app_data.reset_on_error(ms.no_citations_to_save, list_affected_wg = [txt_results])
     return("break")
   
-  doc_filename = app_data.popup_ask_save_file(".xlsx")
+  # Ask user where to save, notify if cancelled
+  try:
+    doc_filename = app_data.popup_ask_save_file(".xlsx")
+  except Exception as e:
+    app_data.update_text_widget(ms.saving_cancelled,
+                          list_affected_wg = [txt_results])
+    return("break")
   
   try:
     message = fm.write_excel(doc_filename,
@@ -162,7 +168,13 @@ def fn_btn_save_txt(event):
     app_data.reset_on_error(ms.no_citations_to_save, list_affected_wg = [txt_results])
     return("break")
   
-  doc_filename = app_data.popup_ask_save_file(".txt")
+  # Ask user where to save, notify if cancelled
+  try:
+    doc_filename = app_data.popup_ask_save_file(".txt")
+  except Exception as e:
+    app_data.update_text_widget(ms.saving_cancelled,
+                          list_affected_wg = [txt_results])
+    return("break")
   
   try:
     message = fm.write_txt(doc_filename,


### PR DESCRIPTION
Fixes bug: a file ".xlsx" or ".txt" would be created on cancelling