### PR TITLE
Prevent error analysing empty clipboard

### DIFF
--- a/PapersCited/UI/windowUI.py
+++ b/PapersCited/UI/windowUI.py
@@ -141,7 +141,12 @@ btn_choose.bind("<ButtonRelease>", lambda event, btn = btn_choose: fn_btn_releas
 def fn_from_clipboard(event):
   btn_from_clipboard.config(relief = "sunken")
 
-  clipboard_text = main_window.clipboard_get()
+  # clipboard_get() errors when clipboard is empty
+  try:
+    clipboard_text = main_window.clipboard_get()
+  
+  except Exception as e:
+    clipboard_text = ""
   
   app_data.set_new_filename(filename = "",
                             list_affected_wg=[lbl_current_file],

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The program comes with a file called "*example.docx*" if you want to experiment 
 - If you get an error reading .doc or .pdf files on Windows, you might need to download additional libraries for working with these files. See [help_with_libraries.txt](https://github.com/Mkranj/PapersCited/blob/main/help_with_libraries.txt) for detailed instructions on how to do so. 
 
 ## Known limitations:
+- Copying PDF text to clipboard might yield unexpected characters, such as *´c* instead of *č*. This depends on the individual PDF file's encoding, however, it might lead to incorrect text scanning. 
 - Secondary citations ("*XX 2010, as cited in YY 2012*"). *YY 2012* is detected correctly. However, *XX 2010* also gets recorded as a primary source. *XX 2010* should not be included in the reference list.
 - In Croatian, different declinations of the author's surnames get detected as different authors.
 - Surnames with three or more words, such as van der Flier, will get recorded only as the last word or last two words - *Kappe and van der Flier (2010)* will be recorded as *Flier 2010*, **skipping the first author**! These require special attention when writing or reviewing a reference list. Multiple surnames with an "*-*", however, will be recorded correctly.


### PR DESCRIPTION
Added limitation: copying from CERTAIN pdf files could yield inaccurate characters, which is part of the PDF encoding and not a fault with the program. It could, however, lead to incorrect text being scanned.
Analysing the PDF file instead of the clipboard could help.

More info: https://stackoverflow.com/a/50359142/21445669